### PR TITLE
Add key bindings to move to parent/root message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Procedure when bumping the version number:
 - `euph.rooms.<name>.password` config option
 - Key binding to change rooms sort order
 - Key bindings to connect to/disconnect from all rooms
-- Key bindings to move to parent/top-level parent
+- Key bindings to move to parent/root
 
 ### Changed
 - Some key bindings in the rooms list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Procedure when bumping the version number:
 - `euph.rooms.<name>.password` config option
 - Key binding to change rooms sort order
 - Key bindings to connect to/disconnect from all rooms
+- Key bindings to move to parent/top-level parent
 
 ### Changed
 - Some key bindings in the rooms list

--- a/src/ui/chat/tree.rs
+++ b/src/ui/chat/tree.rs
@@ -73,6 +73,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         bindings.binding("H/L, ctrl+←/→", "move cursor to prev/next unseen message");
         bindings.binding("g, home", "move cursor to top");
         bindings.binding("G, end", "move cursor to bottom");
+        bindings.binding("p/P", "move cursor to parent/top-level parent");
         bindings.binding("ctrl+y/e", "scroll up/down a line");
         bindings.binding("ctrl+u/d", "scroll up/down half a screen");
         bindings.binding("ctrl+b/f, page up/down", "scroll up/down one screen");
@@ -93,6 +94,8 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             key!('L') | key!(Ctrl + Right) => self.move_cursor_newer_unseen().await,
             key!('g') | key!(Home) => self.move_cursor_to_top().await,
             key!('G') | key!(End) => self.move_cursor_to_bottom().await,
+            key!('p') => self.move_cursor_to_parent().await,
+            key!('P') => self.move_cursor_to_root().await,
             key!(Ctrl + 'y') => self.scroll_up(1),
             key!(Ctrl + 'e') => self.scroll_down(1),
             key!(Ctrl + 'u') => self.scroll_up((chat_height / 2).into()),

--- a/src/ui/chat/tree.rs
+++ b/src/ui/chat/tree.rs
@@ -69,11 +69,11 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     pub fn list_movement_key_bindings(&self, bindings: &mut KeyBindingsList) {
         bindings.binding("j/k, ↓/↑", "move cursor up/down");
         bindings.binding("J/K, ctrl+↓/↑", "move cursor to prev/next sibling");
+        bindings.binding("p/P", "move cursor to parent/root");
         bindings.binding("h/l, ←/→", "move cursor chronologically");
         bindings.binding("H/L, ctrl+←/→", "move cursor to prev/next unseen message");
         bindings.binding("g, home", "move cursor to top");
         bindings.binding("G, end", "move cursor to bottom");
-        bindings.binding("p/P", "move cursor to parent/top-level parent");
         bindings.binding("ctrl+y/e", "scroll up/down a line");
         bindings.binding("ctrl+u/d", "scroll up/down half a screen");
         bindings.binding("ctrl+b/f, page up/down", "scroll up/down one screen");
@@ -88,14 +88,14 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             key!('j') | key!(Down) => self.move_cursor_down().await,
             key!('K') | key!(Ctrl + Up) => self.move_cursor_up_sibling().await,
             key!('J') | key!(Ctrl + Down) => self.move_cursor_down_sibling().await,
+            key!('p') => self.move_cursor_to_parent().await,
+            key!('P') => self.move_cursor_to_root().await,
             key!('h') | key!(Left) => self.move_cursor_older().await,
             key!('l') | key!(Right) => self.move_cursor_newer().await,
             key!('H') | key!(Ctrl + Left) => self.move_cursor_older_unseen().await,
             key!('L') | key!(Ctrl + Right) => self.move_cursor_newer_unseen().await,
             key!('g') | key!(Home) => self.move_cursor_to_top().await,
             key!('G') | key!(End) => self.move_cursor_to_bottom().await,
-            key!('p') => self.move_cursor_to_parent().await,
-            key!('P') => self.move_cursor_to_root().await,
             key!(Ctrl + 'y') => self.scroll_up(1),
             key!(Ctrl + 'e') => self.scroll_down(1),
             key!(Ctrl + 'u') => self.scroll_up((chat_height / 2).into()),

--- a/src/ui/chat/tree/cursor.rs
+++ b/src/ui/chat/tree/cursor.rs
@@ -293,11 +293,10 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             Cursor::Pseudo {
                 parent: Some(parent),
                 ..
-            } => {
-                let id = parent.clone();
-                self.cursor = Cursor::Msg(id);
-            }
+            } => self.cursor = Cursor::Msg(parent.clone()),
             Cursor::Msg(id) => {
+                // Could also be done via retrieving the path, but it doesn't
+                // really matter here
                 let tree = self.store.tree(id).await;
                 Self::find_parent(&tree, id);
             }
@@ -313,13 +312,11 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
                 ..
             } => {
                 let path = self.store.path(parent).await;
-                let root = path.first().clone();
-                self.cursor = Cursor::Msg(root);
+                self.cursor = Cursor::Msg(path.first().clone());
             }
             Cursor::Msg(msg) => {
                 let path = self.store.path(msg).await;
-                let root = path.first().clone();
-                *msg = root;
+                *msg = path.first().clone();
             }
             _ => {}
         }

--- a/src/ui/chat/tree/cursor.rs
+++ b/src/ui/chat/tree/cursor.rs
@@ -180,38 +180,6 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         false
     }
 
-    pub async fn move_cursor_to_parent(&mut self) {
-        match &mut self.cursor {
-            Cursor::Pseudo { parent: Some(parent), .. } => {
-                let id = parent.clone();
-                self.cursor = Cursor::Msg(id);
-            }
-            Cursor::Msg(id) => {
-                let tree = self.store.tree(id).await;
-                Self::find_parent(&tree, id);
-            }
-            _ => {}
-        }
-        self.correction = Some(Correction::MakeCursorVisible);
-    }
-
-    pub async fn move_cursor_to_root(&mut self) {
-        match &mut self.cursor {
-            Cursor::Pseudo { parent: Some(parent), .. } => {
-                let path = self.store.path(parent).await;
-                let root = path.first().clone();
-                self.cursor = Cursor::Msg(root);
-            }
-            Cursor::Msg(msg) => {
-                let path = self.store.path(msg).await;
-                let root = path.first().clone();
-                *msg = root;
-            }
-            _ => {}
-        }
-        self.correction = Some(Correction::MakeCursorVisible);
-    }
-
     pub async fn move_cursor_up(&mut self) {
         match &mut self.cursor {
             Cursor::Bottom | Cursor::Pseudo { parent: None, .. } => {
@@ -314,6 +282,44 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             }
             Cursor::Pseudo { parent: None, .. } => {
                 self.cursor = Cursor::Bottom;
+            }
+            _ => {}
+        }
+        self.correction = Some(Correction::MakeCursorVisible);
+    }
+
+    pub async fn move_cursor_to_parent(&mut self) {
+        match &mut self.cursor {
+            Cursor::Pseudo {
+                parent: Some(parent),
+                ..
+            } => {
+                let id = parent.clone();
+                self.cursor = Cursor::Msg(id);
+            }
+            Cursor::Msg(id) => {
+                let tree = self.store.tree(id).await;
+                Self::find_parent(&tree, id);
+            }
+            _ => {}
+        }
+        self.correction = Some(Correction::MakeCursorVisible);
+    }
+
+    pub async fn move_cursor_to_root(&mut self) {
+        match &mut self.cursor {
+            Cursor::Pseudo {
+                parent: Some(parent),
+                ..
+            } => {
+                let path = self.store.path(parent).await;
+                let root = path.first().clone();
+                self.cursor = Cursor::Msg(root);
+            }
+            Cursor::Msg(msg) => {
+                let path = self.store.path(msg).await;
+                let root = path.first().clone();
+                *msg = root;
             }
             _ => {}
         }

--- a/src/ui/chat/tree/cursor.rs
+++ b/src/ui/chat/tree/cursor.rs
@@ -198,16 +198,14 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     pub async fn move_cursor_to_root(&mut self) {
         match &mut self.cursor {
             Cursor::Pseudo { parent: Some(parent), .. } => {
-                let tree = self.store.tree(parent).await;
-                let mut id = parent.clone();
-                while Self::find_parent(&tree, &mut id) {}
-                self.cursor = Cursor::Msg(id);
+                let path = self.store.path(parent).await;
+                let root = path.first().clone();
+                self.cursor = Cursor::Msg(root);
             }
-            Cursor::Msg(id) => {
-                let mut tree = self.store.tree(id).await;
-                while Self::find_parent(&tree, id) {
-                    tree = self.store.tree(id).await;
-                }
+            Cursor::Msg(msg) => {
+                let path = self.store.path(msg).await;
+                let root = path.first().clone();
+                *msg = root;
             }
             _ => {}
         }


### PR DESCRIPTION
I figured p/P should be shown on the same line in the help cuz it's starting to get crowded in there xP

I left the variables in move_cursor_to_parent as `id`, IDK if you think they're better as `msg`

P should be fixed for pseudo cursors now, and, I guess, faster due to no while loop?

Squash merge if you want, or let me know if you want me to --amend & force push myself.