### PR TITLE
Localize times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1125,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unicode-width = "0.1.10"
 
 [dependencies.time]
 version = "0.3.17"
-features = ["macros", "formatting", "parsing", "serde"]
+features = ["macros", "formatting", "parsing", "serde", "local-offset"]
 
 [dependencies.tokio-tungstenite]
 version = "0.18.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Only defaults :)

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,17 +39,19 @@ pub struct Config {
     pub offline: bool,
     #[serde(default)]
     pub rooms_sort_order: RoomsSortOrder,
+    #[serde(default)]
+    pub timezone_offset: Option<String>,
     // TODO Invoke external notification command?
     pub euph: Euph,
 }
 
 impl Config {
     pub fn load(path: &Path) -> Self {
-        let content = ok_or_return!(fs::read_to_string(path), Self::default());
+        let content  = ok_or_return!(fs::read_to_string(path), Self::default());
         match toml::from_str(&content) {
             Ok(config) => config,
             Err(err) => {
-                println!("Error loading config file: {err}");
+                println!("Error loading   config file: {err}");
                 Self::default()
             }
         }
@@ -57,5 +59,29 @@ impl Config {
 
     pub fn euph_room(&self, name: &str) -> EuphRoom {
         self.euph.rooms.get(name).cloned().unwrap_or_default()
+    }
+
+    pub fn timezone_offset(&self) -> time::UtcOffset {
+        log::info!("timezone_offset: {:?}", self.timezone_offset);
+
+        let default = time::UtcOffset::UTC;
+        if self.timezone_offset.is_none() {
+            return default;
+        }
+
+        let timezone_offset = self.timezone_offset.as_ref().unwrap();
+
+        // Convert to time::UtcOffset
+        // The string is in the format of "hours.minutes.seconds"
+        // Where hours is a signed integer, and minutes and seconds are unsigned integers
+
+        // Split the string into hours, minutes, and seconds
+        let split: Vec<_> = timezone_offset.split(".").collect();
+
+        let hours = split[0].parse::<i8>().unwrap();
+        let minutes = split[1].parse::<i8>().unwrap();
+        let seconds = split[2].parse::<i8>().unwrap();
+
+        time::UtcOffset::from_hms(hours, minutes, seconds).unwrap_or(default)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,11 +47,11 @@ pub struct Config {
 
 impl Config {
     pub fn load(path: &Path) -> Self {
-        let content  = ok_or_return!(fs::read_to_string(path), Self::default());
+        let content = ok_or_return!(fs::read_to_string(path), Self::default());
         match toml::from_str(&content) {
             Ok(config) => config,
             Err(err) => {
-                println!("Error loading   config file: {err}");
+                println!("Error loading config file: {err}");
                 Self::default()
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,10 +146,7 @@ impl Ui {
             if terminal.measuring_required() {
                 let _guard = crossterm_lock.lock();
                 terminal.measure_widths()?;
-                ok_or_return!(
-                    self.event_tx.send(UiEvent::GraphemeWidthsChanged),
-                    Ok(())
-                );
+                ok_or_return!(self.event_tx.send(UiEvent::GraphemeWidthsChanged), Ok(()));
             }
 
             // 2. Handle events (in batches)
@@ -160,8 +157,7 @@ impl Ui {
             let mut redraw = false;
             let end_time = Instant::now() + EVENT_PROCESSING_TIME;
             loop {
-                match self.handle_event(terminal, &crossterm_lock, event).await
-                {
+                match self.handle_event(terminal, &crossterm_lock, event).await {
                     EventHandleResult::Redraw => redraw = true,
                     EventHandleResult::Continue => {}
                     EventHandleResult::Stop => return Ok(()),
@@ -226,13 +222,9 @@ impl Ui {
     ) -> EventHandleResult {
         match event {
             UiEvent::GraphemeWidthsChanged => EventHandleResult::Redraw,
-            UiEvent::LogChanged if self.mode == Mode::Log => {
-                EventHandleResult::Redraw
-            }
+            UiEvent::LogChanged if self.mode == Mode::Log => EventHandleResult::Redraw,
             UiEvent::LogChanged => EventHandleResult::Continue,
-            UiEvent::Term(crossterm::event::Event::Resize(_, _)) => {
-                EventHandleResult::Redraw
-            }
+            UiEvent::Term(crossterm::event::Event::Resize(_, _)) => EventHandleResult::Redraw,
             UiEvent::Term(event) => {
                 self.handle_term_event(terminal, crossterm_lock, event)
                     .await
@@ -253,10 +245,7 @@ impl Ui {
         crossterm_lock: &Arc<FairMutex<()>>,
         event: crossterm::event::Event,
     ) -> EventHandleResult {
-        let event = some_or_return!(
-            InputEvent::from_event(event),
-            EventHandleResult::Continue
-        );
+        let event = some_or_return!(InputEvent::from_event(event), EventHandleResult::Continue);
 
         if let key!(Ctrl + 'c') = event {
             // Exit unconditionally on ctrl+c. Previously, shift+q would also
@@ -268,9 +257,7 @@ impl Ui {
         // Key bindings list overrides any other bindings if visible
         if let Some(key_bindings_list) = &mut self.key_bindings_list {
             match event {
-                key!(Esc) | key!(F 1) | key!('?') => {
-                    self.key_bindings_list = None
-                }
+                key!(Esc) | key!(F 1) | key!('?') => self.key_bindings_list = None,
                 key!('k') | key!(Up) => key_bindings_list.scroll_up(1),
                 key!('j') | key!(Down) => key_bindings_list.scroll_down(1),
                 _ => return EventHandleResult::Continue,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -15,6 +15,7 @@ use toss::frame::{Frame, Size};
 use toss::styled::Styled;
 use toss::terminal::Terminal;
 
+use crate::config::Config;
 use crate::store::{Msg, MsgStore};
 
 use self::tree::{TreeView, TreeViewState};
@@ -52,10 +53,10 @@ pub struct ChatState<M: Msg, S: MsgStore<M>> {
 }
 
 impl<M: Msg, S: MsgStore<M> + Clone> ChatState<M, S> {
-    pub fn new(store: S) -> Self {
+    pub fn new(store: S, config: &'static Config) -> Self {
         Self {
             mode: Mode::Tree,
-            tree: TreeViewState::new(store.clone()),
+            tree: TreeViewState::new(store.clone(), config),
             store,
         }
     }

--- a/src/ui/chat/tree.rs
+++ b/src/ui/chat/tree.rs
@@ -76,10 +76,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         bindings.binding("J/K, ctrl+↓/↑", "move cursor to prev/next sibling");
         bindings.binding("p/P", "move cursor to parent/root");
         bindings.binding("h/l, ←/→", "move cursor chronologically");
-        bindings.binding(
-            "H/L, ctrl+←/→",
-            "move cursor to prev/next unseen message",
-        );
+        bindings.binding("H/L, ctrl+←/→", "move cursor to prev/next unseen message");
         bindings.binding("g, home", "move cursor to top");
         bindings.binding("G, end", "move cursor to bottom");
         bindings.binding("ctrl+y/e", "scroll up/down a line");
@@ -89,39 +86,27 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         // TODO Bindings inspired by vim's ()/[]/{} bindings?
     }
 
-    async fn handle_movement_input_event(
-        &mut self,
-        frame: &mut Frame,
-        event: &InputEvent,
-    ) -> bool {
+    async fn handle_movement_input_event(&mut self, frame: &mut Frame, event: &InputEvent) -> bool {
         let chat_height = frame.size().height - 3;
 
         match event {
             key!('k') | key!(Up) => self.move_cursor_up().await,
             key!('j') | key!(Down) => self.move_cursor_down().await,
             key!('K') | key!(Ctrl + Up) => self.move_cursor_up_sibling().await,
-            key!('J') | key!(Ctrl + Down) => {
-                self.move_cursor_down_sibling().await
-            }
+            key!('J') | key!(Ctrl + Down) => self.move_cursor_down_sibling().await,
             key!('p') => self.move_cursor_to_parent().await,
             key!('P') => self.move_cursor_to_root().await,
             key!('h') | key!(Left) => self.move_cursor_older().await,
             key!('l') | key!(Right) => self.move_cursor_newer().await,
-            key!('H') | key!(Ctrl + Left) => {
-                self.move_cursor_older_unseen().await
-            }
-            key!('L') | key!(Ctrl + Right) => {
-                self.move_cursor_newer_unseen().await
-            }
+            key!('H') | key!(Ctrl + Left) => self.move_cursor_older_unseen().await,
+            key!('L') | key!(Ctrl + Right) => self.move_cursor_newer_unseen().await,
             key!('g') | key!(Home) => self.move_cursor_to_top().await,
             key!('G') | key!(End) => self.move_cursor_to_bottom().await,
             key!(Ctrl + 'y') => self.scroll_up(1),
             key!(Ctrl + 'e') => self.scroll_down(1),
             key!(Ctrl + 'u') => self.scroll_up((chat_height / 2).into()),
             key!(Ctrl + 'd') => self.scroll_down((chat_height / 2).into()),
-            key!(Ctrl + 'b') | key!(PageUp) => {
-                self.scroll_up(chat_height.saturating_sub(1).into())
-            }
+            key!(Ctrl + 'b') | key!(PageUp) => self.scroll_up(chat_height.saturating_sub(1).into()),
             key!(Ctrl + 'f') | key!(PageDown) => {
                 self.scroll_down(chat_height.saturating_sub(1).into())
             }
@@ -139,11 +124,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         bindings.binding("ctrl+s", "mark all older messages as seen");
     }
 
-    async fn handle_action_input_event(
-        &mut self,
-        event: &InputEvent,
-        id: Option<&M::Id>,
-    ) -> bool {
+    async fn handle_action_input_event(&mut self, event: &InputEvent, id: Option<&M::Id>) -> bool {
         match event {
             key!(' ') => {
                 if let Some(id) = id {
@@ -182,14 +163,8 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         false
     }
 
-    pub fn list_edit_initiating_key_bindings(
-        &self,
-        bindings: &mut KeyBindingsList,
-    ) {
-        bindings.binding(
-            "r",
-            "reply to message (inline if possible, else directly)",
-        );
+    pub fn list_edit_initiating_key_bindings(&self, bindings: &mut KeyBindingsList) {
+        bindings.binding("r", "reply to message (inline if possible, else directly)");
         bindings.binding("R", "reply to message (opposite of R)");
         bindings.binding("t", "start a new thread");
     }
@@ -222,11 +197,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         true
     }
 
-    pub fn list_normal_key_bindings(
-        &self,
-        bindings: &mut KeyBindingsList,
-        can_compose: bool,
-    ) {
+    pub fn list_normal_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
         self.list_movement_key_bindings(bindings);
         bindings.empty();
         self.list_action_key_bindings(bindings);
@@ -258,10 +229,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     fn list_editor_key_bindings(&self, bindings: &mut KeyBindingsList) {
         bindings.binding("esc", "close editor");
         bindings.binding("enter", "send message");
-        util::list_editor_key_bindings_allowing_external_editing(
-            bindings,
-            |_| true,
-        );
+        util::list_editor_key_bindings_allowing_external_editing(bindings, |_| true);
     }
 
     fn handle_editor_input_event(
@@ -275,8 +243,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         // TODO Tab-completion
         match event {
             key!(Esc) => {
-                self.cursor =
-                    coming_from.map(Cursor::Msg).unwrap_or(Cursor::Bottom);
+                self.cursor = coming_from.map(Cursor::Msg).unwrap_or(Cursor::Bottom);
                 self.correction = Some(Correction::MakeCursorVisible);
                 return Reaction::Handled;
             }
@@ -293,14 +260,13 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             }
 
             _ => {
-                let handled =
-                    util::handle_editor_input_event_allowing_external_editing(
-                        &self.editor,
-                        terminal,
-                        crossterm_lock,
-                        event,
-                        |_| true,
-                    );
+                let handled = util::handle_editor_input_event_allowing_external_editing(
+                    &self.editor,
+                    terminal,
+                    crossterm_lock,
+                    event,
+                    |_| true,
+                );
                 match handled {
                     Ok(true) => {}
                     Ok(false) => return Reaction::NotHandled,
@@ -313,11 +279,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         Reaction::Handled
     }
 
-    pub fn list_key_bindings(
-        &self,
-        bindings: &mut KeyBindingsList,
-        can_compose: bool,
-    ) {
+    pub fn list_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
         bindings.heading("Chat");
         match &self.cursor {
             Cursor::Bottom | Cursor::Msg(_) => {
@@ -340,12 +302,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         match &self.cursor {
             Cursor::Bottom => {
                 if self
-                    .handle_normal_input_event(
-                        terminal.frame(),
-                        event,
-                        can_compose,
-                        None,
-                    )
+                    .handle_normal_input_event(terminal.frame(), event, can_compose, None)
                     .await
                 {
                     Reaction::Handled
@@ -356,12 +313,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             Cursor::Msg(id) => {
                 let id = id.clone();
                 if self
-                    .handle_normal_input_event(
-                        terminal.frame(),
-                        event,
-                        can_compose,
-                        Some(id),
-                    )
+                    .handle_normal_input_event(terminal.frame(), event, can_compose, Some(id))
                     .await
                 {
                     Reaction::Handled
@@ -395,9 +347,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     fn cursor(&self) -> Option<M::Id> {
         match &self.cursor {
             Cursor::Msg(id) => Some(id.clone()),
-            Cursor::Bottom | Cursor::Editor { .. } | Cursor::Pseudo { .. } => {
-                None
-            }
+            Cursor::Bottom | Cursor::Editor { .. } | Cursor::Pseudo { .. } => None,
         }
     }
 
@@ -417,9 +367,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     }
 }
 
-pub struct TreeViewState<M: Msg, S: MsgStore<M>>(
-    Arc<Mutex<InnerTreeViewState<M, S>>>,
-);
+pub struct TreeViewState<M: Msg, S: MsgStore<M>>(Arc<Mutex<InnerTreeViewState<M, S>>>);
 
 impl<M: Msg, S: MsgStore<M>> TreeViewState<M, S> {
     pub fn new(store: S, config: &'static Config) -> Self {
@@ -434,11 +382,7 @@ impl<M: Msg, S: MsgStore<M>> TreeViewState<M, S> {
         }
     }
 
-    pub async fn list_key_bindings(
-        &self,
-        bindings: &mut KeyBindingsList,
-        can_compose: bool,
-    ) {
+    pub async fn list_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
         self.0.lock().await.list_key_bindings(bindings, can_compose);
     }
 
@@ -482,12 +426,7 @@ where
     M::Id: Send + Sync,
     S: MsgStore<M> + Send + Sync,
 {
-    fn size(
-        &self,
-        _frame: &mut Frame,
-        _max_width: Option<u16>,
-        _max_height: Option<u16>,
-    ) -> Size {
+    fn size(&self, _frame: &mut Frame, _max_width: Option<u16>, _max_height: Option<u16>) -> Size {
         Size::ZERO
     }
 

--- a/src/ui/chat/tree.rs
+++ b/src/ui/chat/tree.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 use toss::frame::{Frame, Pos, Size};
 use toss::terminal::Terminal;
 
+use crate::config::Config;
 use crate::store::{Msg, MsgStore};
 use crate::ui::input::{key, InputEvent, KeyBindingsList};
 use crate::ui::util;
@@ -50,10 +51,12 @@ struct InnerTreeViewState<M: Msg, S: MsgStore<M>> {
     correction: Option<Correction>,
 
     folded: HashSet<M::Id>,
+
+    config: &'static Config,
 }
 
 impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
-    fn new(store: S) -> Self {
+    fn new(store: S, config: &'static Config) -> Self {
         Self {
             store,
             last_cursor: Cursor::Bottom,
@@ -64,6 +67,7 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             scroll: 0,
             correction: None,
             folded: HashSet::new(),
+            config,
         }
     }
 
@@ -72,7 +76,10 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         bindings.binding("J/K, ctrl+↓/↑", "move cursor to prev/next sibling");
         bindings.binding("p/P", "move cursor to parent/root");
         bindings.binding("h/l, ←/→", "move cursor chronologically");
-        bindings.binding("H/L, ctrl+←/→", "move cursor to prev/next unseen message");
+        bindings.binding(
+            "H/L, ctrl+←/→",
+            "move cursor to prev/next unseen message",
+        );
         bindings.binding("g, home", "move cursor to top");
         bindings.binding("G, end", "move cursor to bottom");
         bindings.binding("ctrl+y/e", "scroll up/down a line");
@@ -82,27 +89,39 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         // TODO Bindings inspired by vim's ()/[]/{} bindings?
     }
 
-    async fn handle_movement_input_event(&mut self, frame: &mut Frame, event: &InputEvent) -> bool {
+    async fn handle_movement_input_event(
+        &mut self,
+        frame: &mut Frame,
+        event: &InputEvent,
+    ) -> bool {
         let chat_height = frame.size().height - 3;
 
         match event {
             key!('k') | key!(Up) => self.move_cursor_up().await,
             key!('j') | key!(Down) => self.move_cursor_down().await,
             key!('K') | key!(Ctrl + Up) => self.move_cursor_up_sibling().await,
-            key!('J') | key!(Ctrl + Down) => self.move_cursor_down_sibling().await,
+            key!('J') | key!(Ctrl + Down) => {
+                self.move_cursor_down_sibling().await
+            }
             key!('p') => self.move_cursor_to_parent().await,
             key!('P') => self.move_cursor_to_root().await,
             key!('h') | key!(Left) => self.move_cursor_older().await,
             key!('l') | key!(Right) => self.move_cursor_newer().await,
-            key!('H') | key!(Ctrl + Left) => self.move_cursor_older_unseen().await,
-            key!('L') | key!(Ctrl + Right) => self.move_cursor_newer_unseen().await,
+            key!('H') | key!(Ctrl + Left) => {
+                self.move_cursor_older_unseen().await
+            }
+            key!('L') | key!(Ctrl + Right) => {
+                self.move_cursor_newer_unseen().await
+            }
             key!('g') | key!(Home) => self.move_cursor_to_top().await,
             key!('G') | key!(End) => self.move_cursor_to_bottom().await,
             key!(Ctrl + 'y') => self.scroll_up(1),
             key!(Ctrl + 'e') => self.scroll_down(1),
             key!(Ctrl + 'u') => self.scroll_up((chat_height / 2).into()),
             key!(Ctrl + 'd') => self.scroll_down((chat_height / 2).into()),
-            key!(Ctrl + 'b') | key!(PageUp) => self.scroll_up(chat_height.saturating_sub(1).into()),
+            key!(Ctrl + 'b') | key!(PageUp) => {
+                self.scroll_up(chat_height.saturating_sub(1).into())
+            }
             key!(Ctrl + 'f') | key!(PageDown) => {
                 self.scroll_down(chat_height.saturating_sub(1).into())
             }
@@ -120,7 +139,11 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         bindings.binding("ctrl+s", "mark all older messages as seen");
     }
 
-    async fn handle_action_input_event(&mut self, event: &InputEvent, id: Option<&M::Id>) -> bool {
+    async fn handle_action_input_event(
+        &mut self,
+        event: &InputEvent,
+        id: Option<&M::Id>,
+    ) -> bool {
         match event {
             key!(' ') => {
                 if let Some(id) = id {
@@ -159,8 +182,14 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         false
     }
 
-    pub fn list_edit_initiating_key_bindings(&self, bindings: &mut KeyBindingsList) {
-        bindings.binding("r", "reply to message (inline if possible, else directly)");
+    pub fn list_edit_initiating_key_bindings(
+        &self,
+        bindings: &mut KeyBindingsList,
+    ) {
+        bindings.binding(
+            "r",
+            "reply to message (inline if possible, else directly)",
+        );
         bindings.binding("R", "reply to message (opposite of R)");
         bindings.binding("t", "start a new thread");
     }
@@ -193,7 +222,11 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         true
     }
 
-    pub fn list_normal_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
+    pub fn list_normal_key_bindings(
+        &self,
+        bindings: &mut KeyBindingsList,
+        can_compose: bool,
+    ) {
         self.list_movement_key_bindings(bindings);
         bindings.empty();
         self.list_action_key_bindings(bindings);
@@ -225,7 +258,10 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     fn list_editor_key_bindings(&self, bindings: &mut KeyBindingsList) {
         bindings.binding("esc", "close editor");
         bindings.binding("enter", "send message");
-        util::list_editor_key_bindings_allowing_external_editing(bindings, |_| true);
+        util::list_editor_key_bindings_allowing_external_editing(
+            bindings,
+            |_| true,
+        );
     }
 
     fn handle_editor_input_event(
@@ -239,7 +275,8 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         // TODO Tab-completion
         match event {
             key!(Esc) => {
-                self.cursor = coming_from.map(Cursor::Msg).unwrap_or(Cursor::Bottom);
+                self.cursor =
+                    coming_from.map(Cursor::Msg).unwrap_or(Cursor::Bottom);
                 self.correction = Some(Correction::MakeCursorVisible);
                 return Reaction::Handled;
             }
@@ -256,13 +293,14 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             }
 
             _ => {
-                let handled = util::handle_editor_input_event_allowing_external_editing(
-                    &self.editor,
-                    terminal,
-                    crossterm_lock,
-                    event,
-                    |_| true,
-                );
+                let handled =
+                    util::handle_editor_input_event_allowing_external_editing(
+                        &self.editor,
+                        terminal,
+                        crossterm_lock,
+                        event,
+                        |_| true,
+                    );
                 match handled {
                     Ok(true) => {}
                     Ok(false) => return Reaction::NotHandled,
@@ -275,7 +313,11 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         Reaction::Handled
     }
 
-    pub fn list_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
+    pub fn list_key_bindings(
+        &self,
+        bindings: &mut KeyBindingsList,
+        can_compose: bool,
+    ) {
         bindings.heading("Chat");
         match &self.cursor {
             Cursor::Bottom | Cursor::Msg(_) => {
@@ -298,7 +340,12 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         match &self.cursor {
             Cursor::Bottom => {
                 if self
-                    .handle_normal_input_event(terminal.frame(), event, can_compose, None)
+                    .handle_normal_input_event(
+                        terminal.frame(),
+                        event,
+                        can_compose,
+                        None,
+                    )
                     .await
                 {
                     Reaction::Handled
@@ -309,7 +356,12 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
             Cursor::Msg(id) => {
                 let id = id.clone();
                 if self
-                    .handle_normal_input_event(terminal.frame(), event, can_compose, Some(id))
+                    .handle_normal_input_event(
+                        terminal.frame(),
+                        event,
+                        can_compose,
+                        Some(id),
+                    )
                     .await
                 {
                     Reaction::Handled
@@ -343,7 +395,9 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     fn cursor(&self) -> Option<M::Id> {
         match &self.cursor {
             Cursor::Msg(id) => Some(id.clone()),
-            Cursor::Bottom | Cursor::Editor { .. } | Cursor::Pseudo { .. } => None,
+            Cursor::Bottom | Cursor::Editor { .. } | Cursor::Pseudo { .. } => {
+                None
+            }
         }
     }
 
@@ -363,11 +417,13 @@ impl<M: Msg, S: MsgStore<M>> InnerTreeViewState<M, S> {
     }
 }
 
-pub struct TreeViewState<M: Msg, S: MsgStore<M>>(Arc<Mutex<InnerTreeViewState<M, S>>>);
+pub struct TreeViewState<M: Msg, S: MsgStore<M>>(
+    Arc<Mutex<InnerTreeViewState<M, S>>>,
+);
 
 impl<M: Msg, S: MsgStore<M>> TreeViewState<M, S> {
-    pub fn new(store: S) -> Self {
-        Self(Arc::new(Mutex::new(InnerTreeViewState::new(store))))
+    pub fn new(store: S, config: &'static Config) -> Self {
+        Self(Arc::new(Mutex::new(InnerTreeViewState::new(store, config))))
     }
 
     pub fn widget(&self, nick: String, focused: bool) -> TreeView<M, S> {
@@ -378,7 +434,11 @@ impl<M: Msg, S: MsgStore<M>> TreeViewState<M, S> {
         }
     }
 
-    pub async fn list_key_bindings(&self, bindings: &mut KeyBindingsList, can_compose: bool) {
+    pub async fn list_key_bindings(
+        &self,
+        bindings: &mut KeyBindingsList,
+        can_compose: bool,
+    ) {
         self.0.lock().await.list_key_bindings(bindings, can_compose);
     }
 
@@ -422,7 +482,12 @@ where
     M::Id: Send + Sync,
     S: MsgStore<M> + Send + Sync,
 {
-    fn size(&self, _frame: &mut Frame, _max_width: Option<u16>, _max_height: Option<u16>) -> Size {
+    fn size(
+        &self,
+        _frame: &mut Frame,
+        _max_width: Option<u16>,
+        _max_height: Option<u16>,
+    ) -> Size {
         Size::ZERO
     }
 

--- a/src/ui/chat/tree/layout.rs
+++ b/src/ui/chat/tree/layout.rs
@@ -117,7 +117,7 @@ impl<M: Msg + ChatMsg, S: MsgStore<M>> InnerTreeViewState<M, S> {
         // Main message body
         let highlighted = context.focused && self.cursor.refers_to(id);
         let widget = if let Some(msg) = tree.msg(id) {
-            widgets::msg(highlighted, indent, msg, folded_info)
+            widgets::msg(highlighted, indent, msg, folded_info, self.config)
         } else {
             widgets::msg_placeholder(highlighted, indent, folded_info)
         };

--- a/src/ui/chat/tree/widgets.rs
+++ b/src/ui/chat/tree/widgets.rs
@@ -7,6 +7,7 @@ use toss::styled::Styled;
 use toss::widthdb::WidthDb;
 
 use super::super::ChatMsg;
+use crate::config::Config;
 use crate::store::Msg;
 use crate::ui::widgets::editor::EditorState;
 use crate::ui::widgets::join::{HJoin, Segment};
@@ -56,6 +57,7 @@ pub fn msg<M: Msg + ChatMsg>(
     indent: usize,
     msg: &M,
     folded_info: Option<usize>,
+    config: &Config,
 ) -> BoxedWidget {
     let (nick, mut content) = msg.styled();
 
@@ -68,9 +70,13 @@ pub fn msg<M: Msg + ChatMsg>(
     HJoin::new(vec![
         Segment::new(seen::widget(msg.seen())),
         Segment::new(
-            Padding::new(time::widget(Some(msg.time()), style_time(highlighted)))
-                .stretch(true)
-                .right(1),
+            Padding::new(time::widget(
+                Some(msg.time()),
+                style_time(highlighted),
+                Some(config),
+            ))
+            .stretch(true)
+            .right(1),
         ),
         Segment::new(Indent::new(indent, style_indent(highlighted))),
         Segment::new(Layer::new(vec![
@@ -100,7 +106,7 @@ pub fn msg_placeholder(
     HJoin::new(vec![
         Segment::new(seen::widget(true)),
         Segment::new(
-            Padding::new(time::widget(None, style_time(highlighted)))
+            Padding::new(time::widget(None, style_time(highlighted), None))
                 .stretch(true)
                 .right(1),
         ),
@@ -123,7 +129,7 @@ pub fn editor<M: ChatMsg>(
     let widget = HJoin::new(vec![
         Segment::new(seen::widget(true)),
         Segment::new(
-            Padding::new(time::widget(None, style_editor_highlight()))
+            Padding::new(time::widget(None, style_editor_highlight(), None))
                 .stretch(true)
                 .right(1),
         ),
@@ -139,13 +145,17 @@ pub fn editor<M: ChatMsg>(
     (widget, cursor_row)
 }
 
-pub fn pseudo<M: ChatMsg>(indent: usize, nick: &str, editor: &EditorState) -> BoxedWidget {
+pub fn pseudo<M: ChatMsg>(
+    indent: usize,
+    nick: &str,
+    editor: &EditorState,
+) -> BoxedWidget {
     let (nick, content) = M::edit(nick, &editor.text());
 
     HJoin::new(vec![
         Segment::new(seen::widget(true)),
         Segment::new(
-            Padding::new(time::widget(None, style_pseudo_highlight()))
+            Padding::new(time::widget(None, style_pseudo_highlight(), None))
                 .stretch(true)
                 .right(1),
         ),

--- a/src/ui/chat/tree/widgets.rs
+++ b/src/ui/chat/tree/widgets.rs
@@ -145,11 +145,7 @@ pub fn editor<M: ChatMsg>(
     (widget, cursor_row)
 }
 
-pub fn pseudo<M: ChatMsg>(
-    indent: usize,
-    nick: &str,
-    editor: &EditorState,
-) -> BoxedWidget {
+pub fn pseudo<M: ChatMsg>(indent: usize, nick: &str, editor: &EditorState) -> BoxedWidget {
     let (nick, content) = M::edit(nick, &editor.text());
 
     HJoin::new(vec![

--- a/src/ui/chat/tree/widgets/time.rs
+++ b/src/ui/chat/tree/widgets/time.rs
@@ -2,17 +2,31 @@ use crossterm::style::ContentStyle;
 use time::format_description::FormatItem;
 use time::macros::format_description;
 use time::OffsetDateTime;
+use time::UtcOffset;
 
+use crate::config::Config;
 use crate::ui::widgets::background::Background;
 use crate::ui::widgets::empty::Empty;
 use crate::ui::widgets::text::Text;
 use crate::ui::widgets::BoxedWidget;
 
-const TIME_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day] [hour]:[minute]");
+const TIME_FORMAT: &[FormatItem<'_>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]");
 const TIME_WIDTH: u16 = 16;
 
-pub fn widget(time: Option<OffsetDateTime>, style: ContentStyle) -> BoxedWidget {
+pub fn widget(
+    time: Option<OffsetDateTime>,
+    style: ContentStyle,
+    config: Option<&Config>,
+) -> BoxedWidget {
+    let time_offset = if let Some(config) = config {
+        config.timezone_offset()
+    } else {
+        UtcOffset::UTC
+    };
+
     if let Some(time) = time {
+        let time = time.to_offset(time_offset);
         let text = time.format(TIME_FORMAT).expect("could not format time");
         Background::new(Text::new((text, style)))
             .style(style)

--- a/src/ui/chat/tree/widgets/time.rs
+++ b/src/ui/chat/tree/widgets/time.rs
@@ -10,8 +10,7 @@ use crate::ui::widgets::empty::Empty;
 use crate::ui::widgets::text::Text;
 use crate::ui::widgets::BoxedWidget;
 
-const TIME_FORMAT: &[FormatItem<'_>] =
-    format_description!("[year]-[month]-[day] [hour]:[minute]");
+const TIME_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day] [hour]:[minute]");
 const TIME_WIDTH: u16 = 16;
 
 pub fn widget(

--- a/src/ui/euph/room.rs
+++ b/src/ui/euph/room.rs
@@ -68,19 +68,20 @@ pub struct EuphRoom {
 impl EuphRoom {
     pub fn new(
         server_config: ServerConfig,
-        config: config::EuphRoom,
+        euph_room_config: config::EuphRoom,
         vault: EuphRoomVault,
         ui_event_tx: mpsc::UnboundedSender<UiEvent>,
+		config: &'static config::Config,
     ) -> Self {
         Self {
             server_config,
-            config,
+            config: euph_room_config,
             ui_event_tx,
             room: None,
             focus: Focus::Chat,
             state: State::Normal,
             popups: VecDeque::new(),
-            chat: ChatState::new(vault),
+            chat: ChatState::new(vault, config),
             last_msg_sent: None,
             nick_list: ListState::new(),
         }

--- a/src/ui/euph/room.rs
+++ b/src/ui/euph/room.rs
@@ -71,7 +71,7 @@ impl EuphRoom {
         euph_room_config: config::EuphRoom,
         vault: EuphRoomVault,
         ui_event_tx: mpsc::UnboundedSender<UiEvent>,
-		config: &'static config::Config,
+        config: &'static config::Config,
     ) -> Self {
         Self {
             server_config,

--- a/src/ui/rooms.rs
+++ b/src/ui/rooms.rs
@@ -69,8 +69,8 @@ impl Rooms {
         vault: Vault,
         ui_event_tx: mpsc::UnboundedSender<UiEvent>,
     ) -> Self {
-        let euph_server_config = ServerConfig::default()
-            .cookies(Arc::new(Mutex::new(vault.euph().cookies().await)));
+        let euph_server_config =
+            ServerConfig::default().cookies(Arc::new(Mutex::new(vault.euph().cookies().await)));
 
         let mut result = Self {
             config,
@@ -182,9 +182,7 @@ impl Rooms {
             .then("&", room_style)
             .then(name, room_style)
             .then_plain("?\n\n")
-            .then_plain(
-                "This will delete the entire room history from your vault. ",
-            )
+            .then_plain("This will delete the entire room history from your vault. ")
             .then_plain("To shrink your vault afterwards, run ")
             .then("cove gc", ContentStyle::default().italic().grey())
             .then_plain(".\n\n")
@@ -212,10 +210,14 @@ impl Rooms {
         let mut l = 0_usize;
         let mut n = 0_usize;
 
-        let sessions =
-            joined.listing.values().map(|s| (s.id(), s.name())).chain(
-                iter::once((&joined.session.id, &joined.session.name as &str)),
-            );
+        let sessions = joined
+            .listing
+            .values()
+            .map(|s| (s.id(), s.name()))
+            .chain(iter::once((
+                &joined.session.id,
+                &joined.session.name as &str,
+            )));
         for (user_id, name) in sessions {
             match user_id.session_type() {
                 Some(SessionType::Bot) if name.is_empty() => n += 1,
@@ -277,9 +279,7 @@ impl Rooms {
             (None, Some(u)) => Styled::new_plain(" (")
                 .then(u, unseen_style)
                 .then_plain(")"),
-            (Some(s), None) => {
-                Styled::new_plain(" (").then_plain(s).then_plain(")")
-            }
+            (Some(s), None) => Styled::new_plain(" (").then_plain(s).then_plain(")"),
             (Some(s), Some(u)) => Styled::new_plain(" (")
                 .then_plain(s)
                 .then_plain(", ")
@@ -292,8 +292,7 @@ impl Rooms {
         match self.order {
             Order::Alphabet => rooms.sort_unstable_by_key(|(n, _, _)| *n),
             Order::Importance => rooms.sort_unstable_by_key(|(n, s, u)| {
-                let no_instance =
-                    matches!(s, None | Some(euph::State::Disconnected));
+                let no_instance = matches!(s, None | Some(euph::State::Disconnected));
                 (no_instance, *u == 0, *n)
             }),
         }
@@ -316,8 +315,7 @@ impl Rooms {
         self.sort_rooms(&mut rooms);
         for (name, state, unseen) in rooms {
             let room_style = ContentStyle::default().bold().blue();
-            let room_sel_style =
-                ContentStyle::default().bold().black().on_white();
+            let room_sel_style = ContentStyle::default().bold().black().on_white();
 
             let mut normal = Styled::new(format!("&{name}"), room_style);
             let mut selected = Styled::new(format!("&{name}"), room_sel_style);
@@ -333,16 +331,13 @@ impl Rooms {
     async fn rooms_widget(&self) -> BoxedWidget {
         let heading_style = ContentStyle::default().bold();
         let amount = self.euph_rooms.len();
-        let heading = Text::new(
-            Styled::new("Rooms", heading_style)
-                .then_plain(format!(" ({amount})")),
-        );
+        let heading =
+            Text::new(Styled::new("Rooms", heading_style).then_plain(format!(" ({amount})")));
 
         let mut list = self.list.widget().focus(true);
         self.render_rows(&mut list).await;
 
-        VJoin::new(vec![Segment::new(heading), Segment::new(list).priority(0)])
-            .into()
+        VJoin::new(vec![Segment::new(heading), Segment::new(list).priority(0)]).into()
     }
 
     fn room_char(c: char) -> bool {
@@ -466,8 +461,7 @@ impl Rooms {
                     // really want to panic in case it is not. If I show a
                     // message like this, it'll hopefully be reported if
                     // somebody ever encounters it.
-                    bindings
-                        .binding_ctd("oops, this text should never be visible")
+                    bindings.binding_ctd("oops, this text should never be visible")
                 }
             }
             State::Connect(_) => {
@@ -528,12 +522,7 @@ impl Rooms {
                     return true;
                 }
                 _ => {
-                    if util::handle_editor_input_event(
-                        ed,
-                        terminal,
-                        event,
-                        Self::room_char,
-                    ) {
+                    if util::handle_editor_input_event(ed, terminal, event, Self::room_char) {
                         return true;
                     }
                 }
@@ -550,12 +539,7 @@ impl Rooms {
                     return true;
                 }
                 _ => {
-                    if util::handle_editor_input_event(
-                        editor,
-                        terminal,
-                        event,
-                        Self::room_char,
-                    ) {
+                    if util::handle_editor_input_event(editor, terminal, event, Self::room_char) {
                         return true;
                     }
                 }


### PR DESCRIPTION
# Localize timestamps
- Adds a setting to the config called `timezone_offset`. 
  - It is composed of three integers (positive or negative) separated by dots (`.`)
    - e.g. `-5.0.0` is EST. 
- Updates the timestamps of messages to be offset by that amount. 

# Todo
- Automatically detect time zone from system. 