### PR TITLE
Update GitHub actions used in build runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up rust
         run: rustup update
@@ -36,7 +36,7 @@ jobs:
         run: rustc -vV | awk '/^host/ { print $2 }' > target/release/host
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cove-${{ matrix.os }}
           path: |
@@ -53,7 +53,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Zip artifacts
         run: |
@@ -67,7 +67,7 @@ jobs:
           zip -jr "cove-$(cat cove-macos-15/host).zip"       cove-macos-15/cove
 
       - name: Create new release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: Automated release, see [CHANGELOG.md](CHANGELOG.md) for more details.
           files: "*.zip"


### PR DESCRIPTION
OK, so, this (mostly) works, except there's a problem: there's no `x86_64-apple-darwin` release. This appears to be because `host` file, as produced in the "Record target triple" step, is reporting `aarch64-apple-darwin` on **both** macOS 15 and macOS latest :S (for that matter, I'm not even sure whether the binary produced by the macOS 15 job is an x86 or ["fat" binary](https://en.wikipedia.org/wiki/Fat_binary#Apple's_Universal_binary), as I'ven't checked yet and I'm not sure how to) 

relevant resources:

https://github.com/jeremyredhead/cove/releases/tag/v0.9.4-pre

https://github.com/jeremyredhead/cove/actions/runs/25348777166

(actually, does this need to be a draft commit? i mean, this commit didn't break the host triple :P -- as it's also wrong in [the artifact produced by this build](https://github.com/Garmelon/cove/actions/runs/25341401526#artifacts). (not that you're to blame, really. More like Apple is :P))