### PR TITLE
Add key binding to toggle nick list visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Procedure when bumping the version number:
 
 ## Unreleased
 
+### Added
+
+- Key binding to toggle nick list visibility
+
 ### Changed
 
 - Display emoji user id hashes in the nick list

--- a/cove-config/src/keys.rs
+++ b/cove-config/src/keys.rs
@@ -81,6 +81,7 @@ default_bindings! {
         pub fn nick => ["n"];
         pub fn more_messages => ["m"];
         pub fn account => ["A"];
+        pub fn toggle_nick_list => ["N"];
     }
 
     pub mod tree_cursor {
@@ -288,6 +289,9 @@ pub struct RoomAction {
     /// Manage account.
     #[serde(default = "default::room_action::account")]
     pub account: KeyBinding,
+    /// Show or hide nick list.
+    #[serde(default = "default::room_action::toggle_nick_list")]
+    pub toggle_nick_list: KeyBinding,
 }
 
 #[derive(Debug, Default, Deserialize, Document)]

--- a/cove/src/ui/euph/nick_list.rs
+++ b/cove/src/ui/euph/nick_list.rs
@@ -6,8 +6,8 @@ use euphoxide::{
     client::{Joined, SessionInfo},
 };
 use toss::{
-    Style, Styled, Widget, WidgetExt,
-    widgets::{Background, Text},
+    Style, Styled, WidgetExt,
+    widgets::{Background, BoxedAsync, Text},
 };
 
 use crate::{
@@ -23,10 +23,15 @@ pub fn widget<'a>(
     joined: &Joined,
     focused: bool,
     nick_emoji: bool,
-) -> impl Widget<UiError> + use<'a> {
-    let mut list_builder = ListBuilder::new();
-    render_rows(&mut list_builder, joined, focused, nick_emoji);
-    list_builder.build(list)
+    collapsed: bool,
+) -> BoxedAsync<'a, UiError> {
+    if collapsed {
+        render_summary(joined).desync().boxed_async()
+    } else {
+        let mut list_builder = ListBuilder::new();
+        render_rows(&mut list_builder, joined, focused, nick_emoji);
+        list_builder.build(list).desync().boxed_async()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -64,6 +69,45 @@ impl HalfSession {
             SessionInfo::Full(sess) => Self::from_session_view(sess),
             SessionInfo::Partial(nick) => Self::from_nick_event(nick),
         }
+    }
+}
+
+fn render_summary(joined: &Joined) -> Background<Text> {
+    let mut people = 0;
+    let mut bots = 0;
+    let mut lurkers = 0;
+    let mut nurkers = 0;
+
+    let sessions = joined
+        .listing
+        .values()
+        .map(HalfSession::from_session_info)
+        .chain(iter::once(HalfSession::from_session_view(&joined.session)));
+    for sess in sessions {
+        match sess.id.user_type() {
+            Some(UserType::Bot) if sess.name.is_empty() => nurkers += 1,
+            Some(UserType::Bot) => bots += 1,
+            _ if sess.name.is_empty() => lurkers += 1,
+            _ => people += 1,
+        }
+    }
+
+    // n.b. summary must have a leading space
+    let mut summary = Styled::new_plain("");
+    add_summary_bit(&mut summary, "P", people);
+    add_summary_bit(&mut summary, "B", bots);
+    add_summary_bit(&mut summary, "L", lurkers);
+    add_summary_bit(&mut summary, "N", nurkers);
+
+    Text::new(summary).background()
+}
+
+fn add_summary_bit(so_far: &mut Styled, initial: &str, count: usize) {
+    if count > 0 {
+        *so_far = std::mem::take(so_far)
+            .then_plain(" ")
+            .then(initial, Style::new().bold())
+            .then_plain(format!("{count}"));
     }
 }
 

--- a/cove/src/ui/euph/room.rs
+++ b/cove/src/ui/euph/room.rs
@@ -72,6 +72,7 @@ pub struct EuphRoom {
     last_msg_sent: Option<oneshot::Receiver<MessageId>>,
 
     nick_list: ListState<SessionId>,
+    nick_list_collapsed: bool,
 
     mentioned: bool,
 }
@@ -97,6 +98,7 @@ impl EuphRoom {
             chat: ChatState::new(vault, tz),
             last_msg_sent: None,
             nick_list: ListState::new(),
+            nick_list_collapsed: false,
             mentioned: false,
         }
     }
@@ -211,6 +213,9 @@ impl EuphRoom {
         if self.room_state_joined().is_none() {
             self.focus = Focus::Chat; // There is no nick list to focus on
         }
+        if self.nick_list_collapsed {
+            self.focus = Focus::Chat; // One-line nick list summary isn't focusable
+        }
     }
 
     fn stabilize_state(&mut self) {
@@ -266,6 +271,7 @@ impl EuphRoom {
                 &mut self.nick_list,
                 joined,
                 self.focus,
+                self.nick_list_collapsed,
             ),
             None => Self::widget_without_nick_list(&mut self.chat, status_widget),
         };
@@ -312,29 +318,43 @@ impl EuphRoom {
         nick_list: &'a mut ListState<SessionId>,
         joined: &Joined,
         focus: Focus,
+        nick_list_collapsed: bool,
     ) -> BoxedAsync<'a, UiError> {
         let nick_list_widget = nick_list::widget(
             nick_list,
             joined,
             focus == Focus::NickList,
             chat.nick_emoji(),
+            nick_list_collapsed,
         )
         .padding()
         .with_right(1)
-        .border()
-        .desync();
+        .border();
 
         let chat_widget = chat.widget(joined.session.name.clone(), focus == Focus::Chat);
 
-        Join2::horizontal(
+        if nick_list_collapsed {
             Join2::vertical(
-                status_widget.desync().segment().with_fixed(true),
+                Join2::horizontal(
+                    status_widget.desync().segment(),
+                    nick_list_widget.segment().with_fixed(true),
+                )
+                .segment()
+                .with_fixed(true),
                 chat_widget.segment(),
             )
-            .segment(),
-            nick_list_widget.segment().with_fixed(true),
-        )
-        .boxed_async()
+            .boxed_async()
+        } else {
+            Join2::horizontal(
+                Join2::vertical(
+                    status_widget.desync().segment().with_fixed(true),
+                    chat_widget.segment(),
+                )
+                .segment(),
+                nick_list_widget.segment().with_fixed(true),
+            )
+            .boxed_async()
+        }
     }
 
     async fn status_widget(&self, state: Option<&euph::State>) -> impl Widget<UiError> + use<> {
@@ -443,6 +463,10 @@ impl EuphRoom {
                 }
                 if event.matches(&keys.room.action.account) {
                     self.state = State::Account(AccountUiState::new());
+                    return true;
+                }
+                if event.matches(&keys.room.action.toggle_nick_list) {
+                    self.nick_list_collapsed = !self.nick_list_collapsed;
                     return true;
                 }
             }


### PR DESCRIPTION
Closes #5

this commit actually works perfectly now, it's only still 'WIP' so you can give case of code critiques (INB4 `add_summary_bit` is *too* DRY xD), and for discussion of the Right PBLN/summary format. but yeah! otherwise it works 100% how one would hope/expect! (well, AFAICT -- i did not e.g. test turning off internet whilst nick list collapsed...)

Thank you for all your help & advice with Rust, Garmy! :D

(and yes, no access 4 u to my branch this time >:P plz tell me how 2 fix instead 😇, and i will amend & force push myself)