### PR TITLE
Improve scrolling wrt non-selectable items in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Procedure when bumping the version number:
 ### Fixed
 
 - Emoji shortcodes not always being highlighted or replaced correctly
+- Unselectable items at the start/end of a list were hard to scroll into view
+- Home/End keys did not work in F1 help popup
 
 ## v0.9.3 - 2025-05-31
 

--- a/cove/src/ui/widgets/list.rs
+++ b/cove/src/ui/widgets/list.rs
@@ -201,6 +201,8 @@ impl<Id: Clone> ListState<Id> {
             && let Some(new_cursor) = self.selectable_before_index(cursor.idx)
         {
             self.move_cursor_to(new_cursor);
+        } else {
+            self.scroll_up(1);
         }
     }
 
@@ -210,11 +212,14 @@ impl<Id: Clone> ListState<Id> {
             && let Some(new_cursor) = self.selectable_after_index(cursor.idx)
         {
             self.move_cursor_to(new_cursor);
+        } else {
+            self.scroll_down(1);
         }
     }
 
     /// Move the cursor to the first selectable row.
     pub fn move_cursor_to_top(&mut self) {
+        self.scroll_to(0);
         if let Some(new_cursor) = self.first_selectable() {
             self.move_cursor_to(new_cursor);
         }
@@ -222,6 +227,7 @@ impl<Id: Clone> ListState<Id> {
 
     /// Move the cursor to the last selectable row.
     pub fn move_cursor_to_bottom(&mut self) {
+        self.scroll_to(self.last_rows.len());
         if let Some(new_cursor) = self.last_selectable() {
             self.move_cursor_to(new_cursor);
         }


### PR DESCRIPTION
Before, if you mashed/held down the (heh) Up Arrow or pressed Home in the nick list, you not be able to get "People (n)" back at the top like it starts out, altho one could get it there by pressing page up (for some reason...).

(also, I've only tested the "start" case, not the "end" case, but I'm pretty sure it works too)

"Trivia": These are also both still subtly not 100% correct 105% of the time (arguably), as in the home/end case the very top/bottom might still not be visible if the cursor is so far away from the top/bottom that both couldn't be visible, and conversely in the up/down case, one could (eventually) scroll the cursor off the screen (i think). But these are such degenerate edge cases that I think one needs not worry about them :P (but if they were to be fixed, home/end would need to be changed to "toggle" between first/last selectable item and True start/end. not sure how one would fix/improve up/down tho :p)