### PR TITLE
Add 'archive' to terminal title of archived rooms

### DIFF
--- a/cove/src/ui/euph/room.rs
+++ b/cove/src/ui/euph/room.rs
@@ -376,10 +376,14 @@ impl EuphRoom {
                 .then_plain(")");
         }
 
+        let archive_specifier = match state {
+            None | Some(euph::State::Stopped) => ", archive",
+            _ => "",
+        };
         let title = if unseen > 0 {
-            format!("&{} ({unseen})", self.name())
+            format!("&{}{} ({unseen})", self.name(), archive_specifier)
         } else {
-            format!("&{}", self.name())
+            format!("&{}{}", self.name(), archive_specifier)
         };
 
         Text::new(info)


### PR DESCRIPTION
I can't explain exactly why I thought this should be the case, it just kinda... struck me when I was looking at the code.

Admittedly, I might be going cove code-crazy :P

Feel free to reject this, I'm not even 100% sure it's warranted.